### PR TITLE
feat: add auto-format for mdx files in VSCode with prettier plugin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.tabSize": 2,
+  "json.format.enable": true
+}


### PR DESCRIPTION
adds auto-formatting for MD/MDX files via prettier in VSCode, same settings as we use over at https://github.com/Merit-Circle/beam-subnet

(you need to be using VSCode as your text editor, and install the [prettier plugin](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) for this to work)